### PR TITLE
Select the first _viable_ electricity meter + take gas read on start

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -110,7 +110,7 @@ def get_device_id(gas, electric):
         logging.info("Electricity Meter has been found - {}".format(selected_smart_meter_device_id))
     if gas:
         gas_query = oe_client.execute(gas_query, variable_values={"accountNumber": account_number})
-        meters.append(energy_meter("gas_meter", gas_query["account"]["gasAgreements"][0]["meterPoint"]["meters"][0]["smartGasMeter"]["deviceId"], "gas", 1800, datetime.now(), ["consumption"]))
+        meters.append(energy_meter("gas_meter", gas_query["account"]["gasAgreements"][0]["meterPoint"]["meters"][0]["smartGasMeter"]["deviceId"], "gas", 1800, datetime.now()-timedelta(seconds=1800), ["consumption"]))
         logging.info("Gas Meter has been found - {}".format(gas_query["account"]["gasAgreements"][0]["meterPoint"]["meters"][0]["smartGasMeter"]["deviceId"]))
 
 

--- a/app/app.py
+++ b/app/app.py
@@ -103,8 +103,11 @@ def get_device_id(gas, electric):
 
     if electric:
         electric_query = oe_client.execute(elec_query, variable_values={"accountNumber": account_number})
-        meters.append(energy_meter("electric_meter", electric_query["account"]["electricityAgreements"][0]["meterPoint"]["meters"][0]["smartImportElectricityMeter"]["deviceId"], "electric", int(os.environ.get("INTERVAL")), datetime.now()-timedelta(seconds=interval), ["consumption", "demand"]))
-        logging.info("Electricity Meter has been found - {}".format(electric_query["account"]["electricityAgreements"][0]["meterPoint"]["meters"][0]["smartImportElectricityMeter"]["deviceId"]))
+        usable_smart_meters = [m for m in electric_query["account"]["electricityAgreements"][0]["meterPoint"]["meters"]
+                               if m['smartImportElectricityMeter'] is not None]
+        selected_smart_meter_device_id = usable_smart_meters[0]["smartImportElectricityMeter"]["deviceId"]
+        meters.append(energy_meter("electric_meter", selected_smart_meter_device_id, "electric", int(os.environ.get("INTERVAL")), datetime.now()-timedelta(seconds=interval), ["consumption", "demand"]))
+        logging.info("Electricity Meter has been found - {}".format(selected_smart_meter_device_id))
     if gas:
         gas_query = oe_client.execute(gas_query, variable_values={"accountNumber": account_number})
         meters.append(energy_meter("gas_meter", gas_query["account"]["gasAgreements"][0]["meterPoint"]["meters"][0]["smartGasMeter"]["deviceId"], "gas", 1800, datetime.now(), ["consumption"]))


### PR DESCRIPTION
Hey. I tried this out today but immediately ran into an issue: the first result in the electricity `meters` collection for my account is not a viable smart meter to query. To solve my own problem, here's a super quick PR to filter the response down to just viable scrape targets. I've only done this for electricity because that's my problem—it may make sense to do the same for gas.