### PR TITLE
Improve README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ Prometheus exporter for Octopus Energy metrics. Works best when coupled with an 
 
 - Make use of the docker compose example below or the example in the repo and customise for your use case
 - Set the following environment vars:
-      - PROM_PORT=9120 (Prometheus Port)
-      - INTERVAL=300 (Scraping interval)
-      - API_KEY=abc123 (Octopus Energy API key)
-      - ACCOUNT_NUMBER=A-ABC12E04 (Octopus Energy Account number)
-      - GAS=True (Gas stat scraping)
-      - ELECTRIC=True (Electric stat scraping)
-      - NG_METRICS=False (New for 0.0.24, metrics move to use a proper label format outside of metric names. Defaults to false with existing metric format, setting to True will enable new formatting. This behaviour will change in future major release.)
+  - `PROM_PORT=9120` (Prometheus Port)
+  - `INTERVAL=300` (Scraping interval in seconds)
+  - `API_KEY=abc123` (Octopus Energy API key)
+  - `ACCOUNT_NUMBER=A-ABC12E04` (Octopus Energy Account number)
+  - `GAS=True` (Gas stat scraping)
+  - `ELECTRIC=True` (Electric stat scraping)
+  - `NG_METRICS=False` (New for 0.0.24, metrics move to use a proper label format outside of metric names. Defaults to false with existing metric format, setting to True will enable new formatting. This behaviour will change in future major release.)
 - Ensure the ports exposed in the docker compose match the port referenced under PROM_PORT
 
 ## Docker Compose Example
 
-```
+```yaml
 version: "3.3"
 
 services:


### PR DESCRIPTION
Some tiny QoL improvements in the markdown formatting, the readme now looks like this:

<img width="582" alt="Screenshot 2025-06-29 at 13 43 24" src="https://github.com/user-attachments/assets/20cc309d-1621-4df7-a23a-17f1d736d526" />
