### PR TITLE
Add readtimeout to retryable

### DIFF
--- a/octopus_usage_exporter/octopus_api_connection.py
+++ b/octopus_usage_exporter/octopus_api_connection.py
@@ -86,7 +86,7 @@ class octopus_api_connection(BaseModel):
         self.check_jwt()
         return self.run_query(query, variable_values)
 
-    @retry(retry=retry_if_exception_type((TransportQueryError, ResponseError, requests.exceptions.ConnectionError, requests.exceptions.ConnectTimeout)), wait=wait_exponential(multiplier=1, min=10, max=90), after=after_log(logger, logging.INFO),)
+    @retry(retry=retry_if_exception_type((TransportQueryError, ResponseError, requests.exceptions.ConnectionError, requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout)), wait=wait_exponential(multiplier=1, min=10, max=90), after=after_log(logger, logging.INFO),)
     def run_query(self, query, variable_values=None):
         try:
             return self.client.execute(query, variable_values=variable_values)


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds `requests.exceptions.ReadTimeout` to the list of retryable exceptions in the `run_query` method, ensuring that read timeout errors are handled with the same exponential backoff retry logic as other connection-related exceptions.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `octopus_usage_exporter/octopus_api_connection.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->