### PR TITLE
Add connection failed retrying

### DIFF
--- a/octopus_usage_exporter/octopus_api_connection.py
+++ b/octopus_usage_exporter/octopus_api_connection.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from jose import jwt
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport, log as requests_logger
-from gql.transport.exceptions import TransportQueryError
+from gql.transport.exceptions import TransportQueryError, TransportConnectionFailed
 from urllib3.exceptions import ResponseError, RequestError, HTTPError
 import requests
 from tenacity import retry, wait_exponential, retry_if_exception_type, after_log
@@ -90,6 +90,7 @@ class octopus_api_connection(BaseModel):
         retry=retry_if_exception_type(
             (
                 TransportQueryError,
+                TransportConnectionFailed,
                 ResponseError,
                 RequestError,
                 HTTPError,


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds retry logic for connection failures by including `TransportConnectionFailed` in the list of exceptions that trigger retries. When the Octopus API connection fails, the system will now automatically retry the request using the existing tenacity retry mechanism, making the integration more resilient to transient network issues.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `octopus_usage_exporter/octopus_api_connection.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->