### PR TITLE
move retry logic entirely to retry lib

### DIFF
--- a/octopus_usage_exporter/octopus_api_connection.py
+++ b/octopus_usage_exporter/octopus_api_connection.py
@@ -34,7 +34,7 @@ class octopus_api_connection(BaseModel):
                 url=self.api_url,
                 headers=self.headers,
                 verify=True,
-                retries=2,
+                retries=0,
                 timeout=20),
             fetch_schema_from_transport=False
         )
@@ -97,7 +97,7 @@ class octopus_api_connection(BaseModel):
             )
         ),
         wait=wait_exponential(multiplier=1, min=10, max=90),
-        after=after_log(logger, logging.INFO),
+        after=after_log(logger, logging.WARN),
     )
     def run_query(self, query, variable_values=None):
         try:


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the retry logic to be handled entirely by the retry library (tenacity) by disabling the transport-level retries (setting `retries` to 0) and adjusting the logging level for retry attempts from INFO to WARN. This consolidates retry behavior into a single, more controlled mechanism rather than having overlapping retry strategies at different layers.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `octopus_usage_exporter/octopus_api_connection.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->